### PR TITLE
refactor: destroy bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,4 @@ This is a simple task list of things I need to do to restructure and update the 
 - [ ] update nodejs code to 10x (async)
 - [ ] create sample on how to create an intent
 - [ ] lex chat - show logs and errors! that would be super cool...
+- [ ] remove artifacts folder, generate as needed, remove checked in files (gunk)

--- a/makefile
+++ b/makefile
@@ -53,8 +53,11 @@ deploy-lex:
 deploy: deploy-lambda deploy-lex
 
 # Destroy resources created by 'setup'.
+# This still needs work, the difference between the bot and other resources is
+# seemingly arbitrary.
 destroy:
 	@./scripts/destroy.sh "$(FUNCTION)"
+	@./scripts/destroy-bot.sh destroy-bot "$(REGION)" "lex/bot/Bot.json"
 
 # Utility to show all utterances.
 utterances:

--- a/scripts/destroy-bot.sh
+++ b/scripts/destroy-bot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Abort on any error.
+set -e
+
+# Destroy a bot from its json description.
+# Usage:
+#   destroy-bot us-east-1 ./lex/bot/Bot.json
+function destroy-bot() {
+    region=$1
+    botFile=$2
+
+    # Get the bot name.
+    botName=`cat $botFile | jq -r .name`
+    echo "Found bot '$botName' in '$botFile'..."
+
+    echo "Deleting $botName..."
+    aws lex-models delete-bot --name $botName --region $region
+}
+
+# Allows to call a function based on arguments passed to the script
+$*


### PR DESCRIPTION
The `make destroy` command now deletes the bot itself, completing the
cleanup properly. There may be some restructuring later but this seems
to work well for now.